### PR TITLE
Fix vehicle speed int to double

### DIFF
--- a/autoware/aichallenge_ws/src/aichallenge_eval/src/score.cpp
+++ b/autoware/aichallenge_ws/src/aichallenge_eval/src/score.cpp
@@ -82,7 +82,7 @@ private:
       return;
 
     // 50km/h to m/s
-    if (msg.data < 50 * 1000 / 60 / 60)
+    if (msg.data < 50. * 1000 / 60 / 60)
       return;
 
     result_msg.score = 0;


### PR DESCRIPTION
* 50だとint型であるため、実際の制限速度が47km/hになっている問題があります  
大会のルールだと50km/hが制限である思うので修正を行いました。